### PR TITLE
Fix single frame animations and check for misplaced pivots

### DIFF
--- a/kanimal/Processor/DebonerProcessor.cs
+++ b/kanimal/Processor/DebonerProcessor.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Xml;
+using NLog;
+
+namespace kanimal
+{
+    public class DebonerProcessor : Processor
+    {
+        private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+
+        public override XmlDocument Process(XmlDocument original)
+        {
+            Logger.Warn("Deboning is not currently supported.");
+            return original;
+        }
+    }
+}

--- a/kanimal/Processor/KeyFrameInterpolateProcessor.cs
+++ b/kanimal/Processor/KeyFrameInterpolateProcessor.cs
@@ -159,7 +159,7 @@ namespace kanimal
             /* build the frame array - description is in Alternate.Animation */
             List<List<ProcessingFrame>> frameArray = new List<List<ProcessingFrame>>();
             /* count of frames to know how large the frame array should be */
-            int numberOfFrames = length / interval;
+            int numberOfFrames = length / interval + 1;
             /* for each sprite and bone id a list of frames is created */
             for (int i = 0; i < infoProvider.Size(); i++)
             {

--- a/kanimal/Reader/ScmlReader.cs
+++ b/kanimal/Reader/ScmlReader.cs
@@ -31,6 +31,7 @@ namespace kanimal
 
         public bool AllowMissingSprites = true;
         public bool InterpolateMissingFrames = true;
+        public bool Debone = true;
 
         public ScmlReader(Stream scmlStream, Dictionary<string, Bitmap> sprites)
         {
@@ -45,6 +46,18 @@ namespace kanimal
                 catch (Exception e)
                 {
                     Logger.Fatal($"Failed to interpolate in-between frames. Original exception is as follows:");
+                    ExceptionDispatchInfo.Capture(e).Throw();
+                }
+            }
+            if (Debone)
+            {
+                try
+                {
+                    scml = new DebonerProcessor().Process(scml); // replace the scml with deboned scml
+                }
+                catch (Exception e)
+                {
+                    Logger.Fatal($"Failed to debone the scml document. Original exception is as follows:");
                     ExceptionDispatchInfo.Capture(e).Throw();
                 }
             }
@@ -72,6 +85,18 @@ namespace kanimal
                 catch (Exception e)
                 {
                     Logger.Fatal($"Failed to interpolate in-between frames. Original exception is as follows:");
+                    ExceptionDispatchInfo.Capture(e).Throw();
+                }
+            }
+            if (Debone)
+            {
+                try
+                {
+                    scml = new DebonerProcessor().Process(scml); // replace the scml with deboned scml
+                }
+                catch (Exception e)
+                {
+                    Logger.Fatal($"Failed to debone the scml document. Original exception is as follows:");
                     ExceptionDispatchInfo.Capture(e).Throw();
                 }
             }
@@ -532,6 +557,17 @@ namespace kanimal
                 }
 
                 bank.FrameCount = frameCount;
+                /* if interval is -1 we have encountered an animation with only one keyframe
+                 * because -1 means we weren't able to calculate an interval
+                 * 
+                 * we shouldn't return a rate of -1000 = 1000 / -1 in this case
+                 * instead a logical rate would be to consider the interval
+                 * as just the length of the animation */
+                if (interval == -1)
+                {
+                    Logger.Debug("Encountered an animation with only one keyframe. Interpreting as having an interval between frames equal to the entire duration of the animation.");
+                    interval = int.Parse(anim.GetAttribute("length"));
+                }
                 bank.Rate = (float) Utilities.MS_PER_S / interval;
                 AnimData.Anims.Add(bank);
             }


### PR DESCRIPTION
Add in fix for handling single frame animations in the interpolator.

Also adds checking for if the pivot is assigned manually on any frame (to throw an error).

Some missing things:
1. needs to differentiate between spriter's loop/non-loop animation type. Right now it interpolates everything as a loop rather than only some things.
2. probably should have the interpolation as an optional thing that's hidden behind a flag.

Edit: I know this won't merge as is. Don't try to fix it. I'll make it mergable later this week. Just haven't updated my local stuff to contain and test your renaming things yet.