### PR TITLE
Spritechange symbols

### DIFF
--- a/kanimal/Anim.cs
+++ b/kanimal/Anim.cs
@@ -73,8 +73,9 @@ namespace kanimal
                 {
                     var name = entry.Key;
                     var occurrences = entry.Value;
-                    for (var i = 0; i < occurrences; i++)
+                    for (var i = 0; i < occurrences; i++) {
                         idMap[name.ToSpriterObjectName(i)] = index++;
+                    }
                 }
 
                 ObjectIdMap = idMap;
@@ -127,9 +128,27 @@ namespace kanimal
              */
             public float Order;
 
+            // Finding the name of a sprite should only look at the sprite itself, not its index in the
+            // symbol because this way all indices of a symbol can be part of the same timeline and just
+            // be sprite-swapped between in the SCML
             public SpriteName FindName(AnimHashTable animHashes)
             {
+                return new SpriteName(animHashes[ImageHash]);
+            }
+
+            // This method gets the name of the sprite plus its index which we don't use when building our internal
+            // representation of the animation but we need to use in order to reference the sprite on disk for actually
+            // indicating which sprite out of the symbol's frames we need to swap to on any given frame
+            public SpriteName FindNameWithIndex(AnimHashTable animHashes)
+            {
                 return new SpriteName($"{animHashes[ImageHash]}_{Index}");
+            }
+
+            // This gets the name of the sprite but at any given index in the symbol. This is important for testing if certain indices
+            // exist within a given symbol
+            public SpriteName FindNameWithGivenIndex(AnimHashTable animHashes, int index)
+            {
+                return new SpriteName($"{animHashes[ImageHash]}_{index}");
             }
 
             // Takes the matrix values and returns a typical separate-component transform object

--- a/kanimal/Processor/DebonerProcessor.cs
+++ b/kanimal/Processor/DebonerProcessor.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Xml;
+using NLog;
+
+namespace kanimal
+{
+    public class DebonerProcessor : Processor
+    {
+        private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+
+        public override XmlDocument Process(XmlDocument original)
+        {
+            Logger.Warn("Deboning is not currently supported.");
+            return original;
+        }
+    }
+}

--- a/kanimal/Processor/KeyFrameInterpolateProcessor.cs
+++ b/kanimal/Processor/KeyFrameInterpolateProcessor.cs
@@ -159,7 +159,7 @@ namespace kanimal
             /* build the frame array - description is in Alternate.Animation */
             List<List<ProcessingFrame>> frameArray = new List<List<ProcessingFrame>>();
             /* count of frames to know how large the frame array should be */
-            int numberOfFrames = length / interval;
+            int numberOfFrames = length / interval + 1;
             /* for each sprite and bone id a list of frames is created */
             for (int i = 0; i < infoProvider.Size(); i++)
             {

--- a/kanimal/Reader/ScmlReader.cs
+++ b/kanimal/Reader/ScmlReader.cs
@@ -31,6 +31,7 @@ namespace kanimal
 
         public bool AllowMissingSprites = true;
         public bool InterpolateMissingFrames = true;
+        public bool Debone = true;
 
         public ScmlReader(Stream scmlStream, Dictionary<string, Bitmap> sprites)
         {
@@ -45,6 +46,18 @@ namespace kanimal
                 catch (Exception e)
                 {
                     Logger.Fatal($"Failed to interpolate in-between frames. Original exception is as follows:");
+                    ExceptionDispatchInfo.Capture(e).Throw();
+                }
+            }
+            if (Debone)
+            {
+                try
+                {
+                    scml = new DebonerProcessor().Process(scml); // replace the scml with deboned scml
+                }
+                catch (Exception e)
+                {
+                    Logger.Fatal($"Failed to debone the scml document. Original exception is as follows:");
                     ExceptionDispatchInfo.Capture(e).Throw();
                 }
             }
@@ -72,6 +85,18 @@ namespace kanimal
                 catch (Exception e)
                 {
                     Logger.Fatal($"Failed to interpolate in-between frames. Original exception is as follows:");
+                    ExceptionDispatchInfo.Capture(e).Throw();
+                }
+            }
+            if (Debone)
+            {
+                try
+                {
+                    scml = new DebonerProcessor().Process(scml); // replace the scml with deboned scml
+                }
+                catch (Exception e)
+                {
+                    Logger.Fatal($"Failed to debone the scml document. Original exception is as follows:");
                     ExceptionDispatchInfo.Capture(e).Throw();
                 }
             }
@@ -532,6 +557,17 @@ namespace kanimal
                 }
 
                 bank.FrameCount = frameCount;
+                /* if interval is -1 we have encountered an animation with only one keyframe
+                 * because -1 means we weren't able to calculate an interval
+                 * 
+                 * we shouldn't return a rate of -1000 = 1000 / -1 in this case
+                 * instead a logical rate would be to consider the interval
+                 * as just the length of the animation */
+                if (interval == -1)
+                {
+                    Logger.Debug("Encountered an animation with only one keyframe. Interpreting as having an interval between frames equal to the entire duration of the animation.");
+                    interval = int.Parse(anim.GetAttribute("length"));
+                }
                 bank.Rate = (float) Utilities.MS_PER_S / interval;
                 AnimData.Anims.Add(bank);
             }


### PR DESCRIPTION
Rolls in the changes from the previous pr that I closed. Makes up-to-date with master.

Includes the previous changes for properly handling single frame animations.
Also has code for erroring on improper pivots.
Still missing code for interpolating properly/differently based on if the spriter animation is looped or just single time.

Now also fixes two bugs in kanim -> spriter conversion:
1. by making each symbol a timeline with sprite swaps rather than each sprite in a symbol a timeline, this makes the animation of symbols smooth in the way they are supposed to be.
2. fixes bug where some klei animations only have 1/2 of the frames in a symbol specified in the build file but the animation file references all the frames by searching for a preceding frame if the current frame the animation references is missing