### PR TITLE
Interpolate opt in

### DIFF
--- a/kanimal-cli/Options.cs
+++ b/kanimal-cli/Options.cs
@@ -19,6 +19,13 @@ namespace kanimal_cli
     {
         [Option('S', "strict", Required = false, HelpText = "When writing to scml, enabling this flag ")]
         public bool Strict { get; set; }
+
+        [Option('i', "interpolate", Required = false, HelpText = "Enable interpolating scml files on load.")]
+        public bool Interp { get; set; }
+
+        [Option('b', "debone", Required = false, HelpText = "Enable deboning scml files on load.")]
+        public bool Debone { get; set; }
+
     }
 
     [Verb("dump", HelpText = "Output a dump of the specified kanim.")]

--- a/kanimal-cli/Program.cs
+++ b/kanimal-cli/Program.cs
@@ -58,7 +58,10 @@ namespace kanimal_cli
                     var scml = files.Find(path => path.EndsWith(".scml"));
                     var scmlreader = new ScmlReader(scml)
                     {
-                        AllowMissingSprites = !opt.Strict
+                        AllowMissingSprites = !opt.Strict,
+                        AllowInFramePivots = !opt.Strict,
+                        InterpolateMissingFrames = opt.Interp,
+                        Debone = opt.Debone
                     };
                     scmlreader.Read();
                     reader = scmlreader;

--- a/kanimal-cli/Program.cs
+++ b/kanimal-cli/Program.cs
@@ -115,7 +115,8 @@ namespace kanimal_cli
                 case "scml":
                     var scmlWriter = new ScmlWriter(reader)
                     {
-                        FillMissingSprites = !opt.Strict
+                        FillMissingSprites = !opt.Strict,
+                        AllowDuplicateSprites = !opt.Strict
                     };
                     scmlWriter.SaveToDir(Path.Join(opt.OutputPath));
                     break;

--- a/kanimal/Processor/KeyFrameInterpolateProcessor.cs
+++ b/kanimal/Processor/KeyFrameInterpolateProcessor.cs
@@ -75,6 +75,11 @@ namespace kanimal
         /* the length of the animation in milliseconds - integer */
         public int Length { get; set; }
 
+        /* if the animation is looped - i.e. does the interpolator
+         * consider the animation as wrapping around from the end-to-the-start
+         * or does it consider the end as not having to match up with the start */
+        public bool Looping { get; set; }
+
         /* 2d array of the frames, 1st axis is the ids of the timelines for all
          * of the sprites and bones in the animation, 2nd axis is the timesteps */
         public List<List<ProcessingFrame>> FrameArray { get; set; }
@@ -354,6 +359,12 @@ namespace kanimal
                 }
             }
 
+            var looping = true;
+            if (animation.HasAttribute("looping"))
+            {
+                looping = bool.Parse(animation.Attributes["looping"].Value);
+            }
+
             /* create an additional array that indicates presence of each timeline on a per-frame basis */
             List<List<bool>> presenceArray = new List<List<bool>>();
             for (int i = 0; i < infoProvider.Size(); i++)
@@ -380,21 +391,21 @@ namespace kanimal
                     }
                     presenceArray[i][j] = currentPresence;
                 }
-                for (int j = 0; j < numberOfFrames; j++)
-                {
-                    /* if this frame is a key frame then update the current presence based on if there
-                     * is a frame populated at this location */
-                    if (keyFrames[j])
-                    {
-                        currentPresence = (frameArray[i][j] != null);
-                    }
-                    presenceArray[i][j] = currentPresence;
-                }
                 /* executing the loop twice is the most straightforward way to ensure that a keyframe at the end
-                 * of the timeline wraps around to the front of the timeline
-                 * this does mess with animations that aren't looped that don't have keyframes at time = 0 but that just doesn't make
-                 * much sense (who wouldn't keyframe at time = 0 for a non-looping animation!)
-                 * so I'll just document that and ignore that problem for now */
+                 * of the timeline wraps around to the front of the timeline */
+                if (looping)
+                {
+                    for (int j = 0; j < numberOfFrames; j++)
+                    {
+                        /* if this frame is a key frame then update the current presence based on if there
+                         * is a frame populated at this location */
+                        if (keyFrames[j])
+                        {
+                            currentPresence = (frameArray[i][j] != null);
+                        }
+                        presenceArray[i][j] = currentPresence;
+                    }
+                }
             }
 
             /* for every frame with presence in the array set to true that still has a null frame
@@ -419,25 +430,28 @@ namespace kanimal
                         beforeFrame = frameArray[i][j];
                         beforeFrameIndex = j;
                         /* probe forward to find the after array when a before array is found
-                         * will use a endless loop because eventually at least we know we will
-                         * terminate when it hits the exact same before array */
+                         * if not looping it only probes until the end of the timeline */
                         int jPrime = j + 1;
-                        if (jPrime >= numberOfFrames)
+                        if (jPrime < numberOfFrames || looping)
                         {
-                            jPrime = 0;
-                        }
-                        while (presenceArray[i][jPrime])
-                        {
-                            if (frameArray[i][jPrime] != null && frameArray[i][jPrime].IsPopulated())
-                            {
-                                afterFrame = frameArray[i][jPrime];
-                                afterFrameIndex = jPrime;
-                                break;
-                            }
-                            jPrime++;
                             if (jPrime >= numberOfFrames)
                             {
                                 jPrime = 0;
+                            }
+                            while (presenceArray[i][jPrime] &&
+                                (looping || jPrime < numberOfFrames))
+                            {
+                                if (frameArray[i][jPrime] != null && frameArray[i][jPrime].IsPopulated())
+                                {
+                                    afterFrame = frameArray[i][jPrime];
+                                    afterFrameIndex = jPrime;
+                                    break;
+                                }
+                                jPrime++;
+                                if (jPrime >= numberOfFrames)
+                                {
+                                    jPrime = 0;
+                                }
                             }
                         }
                         /* if we found a before frame but couldn't find an after frame this means that there was a frame that is completely defined
@@ -470,80 +484,77 @@ namespace kanimal
                         frameArray[i][j].Populate(beforeFrame.Folder, beforeFrame.File, x, y, angle, xScale, yScale);
                     }
                 }
-            }
-            for (int i = 0; i < infoProvider.Size(); i++)
-            {
-                ProcessingFrame beforeFrame = null;
-                ProcessingFrame afterFrame = null;
-                int beforeFrameIndex = -1;
-                int afterFrameIndex = -1;
-                for (int j = 0; j < numberOfFrames; j++)
+                /* interpolation is run twice to fix issue where time = 0 is not key frame
+                 * since otherwise every frame before the first keyframe will not be processed */
+                if (looping)
                 {
-                    /* skip this frame if it isn't supposed to be present */
-                    if (!presenceArray[i][j])
+                    for (int j = 0; j < numberOfFrames; j++)
                     {
-                        continue;
-                    }
-                    /* if this frame exists and is populated then it will be used
-                     * as the before frame */
-                    if (frameArray[i][j] != null && frameArray[i][j].IsPopulated())
-                    {
-                        beforeFrame = frameArray[i][j];
-                        beforeFrameIndex = j;
-                        /* probe forward to find the after array when a before array is found
-                         * will use a endless loop because eventually at least we know we will
-                         * terminate when it hits the exact same before array */
-                        int jPrime = j + 1;
-                        if (jPrime >= numberOfFrames)
+                        /* skip this frame if it isn't supposed to be present */
+                        if (!presenceArray[i][j])
                         {
-                            jPrime = 0;
+                            continue;
                         }
-                        while (presenceArray[i][jPrime])
+                        /* if this frame exists and is populated then it will be used
+                         * as the before frame */
+                        if (frameArray[i][j] != null && frameArray[i][j].IsPopulated())
                         {
-                            if (frameArray[i][jPrime] != null && frameArray[i][jPrime].IsPopulated())
-                            {
-                                afterFrame = frameArray[i][jPrime];
-                                afterFrameIndex = jPrime;
-                                break;
-                            }
-                            jPrime++;
+                            beforeFrame = frameArray[i][j];
+                            beforeFrameIndex = j;
+                            /* probe forward to find the after array when a before array is found
+                             * will use a endless loop because eventually at least we know we will
+                             * terminate when it hits the exact same before array */
+                            int jPrime = j + 1;
                             if (jPrime >= numberOfFrames)
                             {
                                 jPrime = 0;
                             }
+                            while (presenceArray[i][jPrime])
+                            {
+                                if (frameArray[i][jPrime] != null && frameArray[i][jPrime].IsPopulated())
+                                {
+                                    afterFrame = frameArray[i][jPrime];
+                                    afterFrameIndex = jPrime;
+                                    break;
+                                }
+                                jPrime++;
+                                if (jPrime >= numberOfFrames)
+                                {
+                                    jPrime = 0;
+                                }
+                            }
+                            /* if we found a before frame but couldn't find an after frame this means that there was a frame that is completely defined
+                             * but there are more frames that need to be interpolated from this frame only
+                             * since this is the only frame, spriter interprets this frame as being the frame used for all of the interpolated positions
+                             * in which this sprite exists */
+                            if (afterFrame == null)
+                            {
+                                Logger.Debug("Could not find after frame to interpolate between. Interpreting this to mean that this frame is expected to take the entire duration of the timeline.");
+                                afterFrame = beforeFrame;
+                                afterFrameIndex = beforeFrameIndex;
+                            }
                         }
-                        /* if we found a before frame but couldn't find an after frame this means that there was a frame that is completely defined
-                         * but there are more frames that need to be interpolated from this frame only
-                         * since this is the only frame, spriter interprets this frame as being the frame used for all of the interpolated positions
-                         * in which this sprite exists */
-                        if (afterFrame == null)
+                        else if (beforeFrame != null && afterFrame != null)
                         {
-                            Logger.Debug("Could not find after frame to interpolate between. Interpreting this to mean that this frame is expected to take the entire duration of the timeline.");
-                            afterFrame = beforeFrame;
-                            afterFrameIndex = beforeFrameIndex;
+                            float x = LinearInterpolate(beforeFrame.X, afterFrame.X, beforeFrameIndex,
+                                afterFrameIndex + ((afterFrameIndex < beforeFrameIndex) ? numberOfFrames : 0), j);
+                            float y = LinearInterpolate(beforeFrame.Y, afterFrame.Y, beforeFrameIndex,
+                                afterFrameIndex + ((afterFrameIndex < beforeFrameIndex) ? numberOfFrames : 0), j);
+                            float angle = LinearInterpolateAngle(beforeFrame.Angle, afterFrame.Angle, beforeFrameIndex,
+                                afterFrameIndex + ((afterFrameIndex < beforeFrameIndex) ? numberOfFrames : 0), j);
+                            float xScale = LinearInterpolate(beforeFrame.ScaleX, afterFrame.ScaleX, beforeFrameIndex,
+                                afterFrameIndex + ((afterFrameIndex < beforeFrameIndex) ? numberOfFrames : 0), j);
+                            float yScale = LinearInterpolate(beforeFrame.ScaleY, afterFrame.ScaleY, beforeFrameIndex,
+                                afterFrameIndex + ((afterFrameIndex < beforeFrameIndex) ? numberOfFrames : 0), j);
+                            if (frameArray[i][j] == null)
+                            {
+                                frameArray[i][j] = new ProcessingFrame(beforeFrame.ParentId, beforeFrame.ZIndex);
+                            }
+                            frameArray[i][j].Populate(beforeFrame.Folder, beforeFrame.File, x, y, angle, xScale, yScale);
                         }
-                    }
-                    else if (beforeFrame != null && afterFrame != null)
-                    {
-                        float x = LinearInterpolate(beforeFrame.X, afterFrame.X, beforeFrameIndex,
-                            afterFrameIndex + ((afterFrameIndex < beforeFrameIndex) ? numberOfFrames : 0), j);
-                        float y = LinearInterpolate(beforeFrame.Y, afterFrame.Y, beforeFrameIndex,
-                            afterFrameIndex + ((afterFrameIndex < beforeFrameIndex) ? numberOfFrames : 0), j);
-                        float angle = LinearInterpolateAngle(beforeFrame.Angle, afterFrame.Angle, beforeFrameIndex,
-                            afterFrameIndex + ((afterFrameIndex < beforeFrameIndex) ? numberOfFrames : 0), j);
-                        float xScale = LinearInterpolate(beforeFrame.ScaleX, afterFrame.ScaleX, beforeFrameIndex,
-                            afterFrameIndex + ((afterFrameIndex < beforeFrameIndex) ? numberOfFrames : 0), j);
-                        float yScale = LinearInterpolate(beforeFrame.ScaleY, afterFrame.ScaleY, beforeFrameIndex,
-                            afterFrameIndex + ((afterFrameIndex < beforeFrameIndex) ? numberOfFrames : 0), j);
-                        if (frameArray[i][j] == null)
-                        {
-                            frameArray[i][j] = new ProcessingFrame(beforeFrame.ParentId, beforeFrame.ZIndex);
-                        }
-                        frameArray[i][j].Populate(beforeFrame.Folder, beforeFrame.File, x, y, angle, xScale, yScale);
                     }
                 }
             }
-            /* interpolation is run twice to fix issue where time = 0 is not key frame */
 
             return new ProcessingAnimation(name, interval, length, frameArray, infoProvider);
         }

--- a/kanimal/Reader/ScmlReader.cs
+++ b/kanimal/Reader/ScmlReader.cs
@@ -129,6 +129,9 @@ namespace kanimal
             Logger.Info("Reading image files.");
             ReadProjectSprites();
 
+            // Only use the sprites that are included in the project
+            inputSprites = inputSprites.Where(sprite => projectSprites.ContainsKey(sprite.Key.ToSpriteName())).ToDictionary(x => x.Key, x => x.Value);
+
             // Also set the output list of sprites
             Sprites = new List<Sprite>();
             Sprites = inputSprites.Select(sprite => new Sprite {Bitmap = sprite.Value, Name = sprite.Key.ToSpriteName()}).ToList();

--- a/kanimal/Reader/ScmlReader.cs
+++ b/kanimal/Reader/ScmlReader.cs
@@ -34,8 +34,10 @@ namespace kanimal
         public bool InterpolateMissingFrames = true;
         public bool Debone = true;
 
-        private XmlDocument HandleProcessors(XmlDocument scml)
+        public ScmlReader(Stream scmlStream, Dictionary<Filename, Bitmap> sprites)
         {
+            scml = new XmlDocument();
+            scml.Load(scmlStream);
             if (InterpolateMissingFrames)
             {
                 try
@@ -60,14 +62,7 @@ namespace kanimal
                     ExceptionDispatchInfo.Capture(e).Throw();
                 }
             }
-            return scml;
-        }
 
-        public ScmlReader(Stream scmlStream, Dictionary<Filename, Bitmap> sprites)
-        {
-            scml = new XmlDocument();
-            scml.Load(scmlStream);
-            scml = HandleProcessors(scml);
             inputSprites = sprites;
         }
         
@@ -83,7 +78,30 @@ namespace kanimal
                 Logger.Fatal($"You must specify a path to load the SCML from. Original exception is as follows:");
                 ExceptionDispatchInfo.Capture(e).Throw();
             }
-            scml = HandleProcessors(scml);
+            if (InterpolateMissingFrames)
+            {
+                try
+                {
+                    scml = new KeyFrameInterpolateProcessor().Process(scml); // replace the scml with fully keyframed scml
+                }
+                catch (Exception e)
+                {
+                    Logger.Fatal($"Failed to interpolate in-between frames. Original exception is as follows:");
+                    ExceptionDispatchInfo.Capture(e).Throw();
+                }
+            }
+            if (Debone)
+            {
+                try
+                {
+                    scml = new DebonerProcessor().Process(scml); // replace the scml with deboned scml
+                }
+                catch (Exception e)
+                {
+                    Logger.Fatal($"Failed to debone the scml document. Original exception is as follows:");
+                    ExceptionDispatchInfo.Capture(e).Throw();
+                }
+            }
             // Due to scml conventions, our input directory is the same as the scml file's
             var inputDir = Path.Join(scmlpath, "../");
             inputSprites = new Dictionary<Filename, Bitmap>();
@@ -289,9 +307,6 @@ namespace kanimal
                 Logger.Debug($"bank.name={bank.Name}\nhashTable={bank.Hash}");
                 bank.Frames = new List<KAnim.Frame>();
 
-                // the consistent interval between frames
-                // -1 indicates it starts off as being unknown
-                // since all valid values for the interval will be >= 0
                 var interval = -1;
 
                 var timelines = anim.ChildNodes;

--- a/kanimal/Reader/ScmlReader.cs
+++ b/kanimal/Reader/ScmlReader.cs
@@ -130,7 +130,15 @@ namespace kanimal
             ReadProjectSprites();
 
             // Only use the sprites that are included in the project
+            List<SpriteName> allSprites = inputSprites.Select(sprite => sprite.Key.ToSpriteName()).ToList();
             inputSprites = inputSprites.Where(sprite => projectSprites.ContainsKey(sprite.Key.ToSpriteName())).ToDictionary(x => x.Key, x => x.Value);
+            List<SpriteName> usedSprites = inputSprites.Select(sprite => sprite.Key.ToSpriteName()).ToList();
+
+            List<string> unusedSprites = allSprites.FindAll(sprite => !usedSprites.Contains(sprite)).Select(sprite => sprite.ToFilename().ToString()).ToList();
+            if (unusedSprites.Count > 0)
+            {
+                Logger.Warn($"There were unused sprites in the SCML project folder: {unusedSprites.Join()}. Did you forget to included these in the SCML file? You must manually add in files that are part of a symbol_override if they aren't explicitly placed into any animations in the SCML. ");
+            }
 
             // Also set the output list of sprites
             Sprites = new List<Sprite>();

--- a/kanimal/Reader/ScmlReader.cs
+++ b/kanimal/Reader/ScmlReader.cs
@@ -30,6 +30,7 @@ namespace kanimal
         private Dictionary<Filename, Bitmap> inputSprites; // The keys in this dictionary are filenames, *with* the file extension, if it exists.
 
         public bool AllowMissingSprites = true;
+        public bool AllowInFramePivots = true;
         public bool InterpolateMissingFrames = true;
         public bool Debone = true;
 
@@ -587,15 +588,26 @@ namespace kanimal
             if (hasInconsistentIntervals)
             {
                 var anims = inconsistentAnims.ToList().Join();
-                throw new ProjectParseException(
-                    $"SCML format exception: The intervals in the anims {anims} were inconsistent. Aborting read.");
+                string error = $"SCML format exception: The intervals in the anims {anims} were inconsistent. Aborting read.";
+                if (!InterpolateMissingFrames)
+                {
+                    error += " Try enabling keyframe interpolation with the \"-i\" flag and try again.";
+                }
+                throw new ProjectParseException(error);
             }
 
             if (hasPivotsSpecifiedInTimeline)
             {
                 var anims = pivotAnims.ToList().Join();
-                throw new ProjectParseException(
-                    $"SCML format exception: There were pivot points specified in timelines rather than only on the sprites in anims {anims}. Aborting read.");
+                if (AllowInFramePivots)
+                {
+                    Logger.Warn($"Encountered pivot points specified in timelines in anims {anims}. These pivot point changes will not be respected. Strict-mode is off. Converting anyway.");
+                }
+                else
+                {
+                    throw new ProjectParseException($"SCML format exception: There were pivot points specified in timelines rather than only on the sprites in anims {anims}. Aborting read.");
+                }
+
             }
 
             AnimData.AnimCount = animCount;

--- a/kanimal/Writer/ScmlWriter.cs
+++ b/kanimal/Writer/ScmlWriter.cs
@@ -112,7 +112,7 @@ namespace kanimal
 
                     var fileNode = Scml.CreateElement("file");
                     fileNode.SetAttribute("id", fileIndex.ToString());
-                    fileNode.SetAttribute("name", $"{row.Name}_{row.Index}");
+                    fileNode.SetAttribute("name", $"{row.Name}_{row.Index}.png");
                     fileNode.SetAttribute("width", ((int) row.Width).ToString());
                     fileNode.SetAttribute("height", ((int) row.Height).ToString());
                     fileNode.SetAttribute("pivot_x", pivotX.ToStringInvariant());

--- a/kanimal/Writer/ScmlWriter.cs
+++ b/kanimal/Writer/ScmlWriter.cs
@@ -22,6 +22,7 @@ namespace kanimal
         protected XmlElement Entity;
 
         public bool FillMissingSprites = true; // When true, if a file is referenced in frames but doesn't exist as a sprite, add it as a blank 1x1 sprite.
+        public bool AllowDuplicateSprites = true; // When true if a sprite is defined multiple times, only utilize the first definition.
 
         public ScmlWriter(Reader reader)
         {
@@ -97,7 +98,14 @@ namespace kanimal
                     var key = row.GetSpriteName().ToFilename();
                     if (filenameindex.ContainsKey(key))
                     {
-                        throw new Exception($"filenameindex already contains a key for the sprite {key.Value}!");
+                        if (AllowDuplicateSprites)
+                        {
+                            Logger.Warn($"Duplicate sprite for {key.Value}. This may be indicative of a problem with the source file.");
+                        }
+                        else
+                        {
+                            throw new Exception($"filenameindex already contains a key for the sprite {key.Value}! Try again without strict mode if you believe this is in error.");
+                        }
                     }
 
                     filenameindex[key] = fileIndex;


### PR DESCRIPTION
* Interpolation and debone are opt-in now
* Pivots being specified in timeline frames is now a warning in normal mode and error in strict rather than always an error.
* Still don't handle looping properly because I haven't managed to figure out how the interpolator should actually work when the 1st and last frame aren't defined - I'll get there eventually.
* Make it so SCML reading doesn't break when there are extra image files in the directory that aren't used by the project - additionally now warns the user of this case since this probably is unintentional.
* SCML writing should write file extension ".png" into the file names in the SCML because spriter expects the full file name including extension.
* Also downgrades duplicate sprite to just a warning unless strict mode is enabled.