### PR TITLE
Non-english locale support, symbol count bug fix

### DIFF
--- a/kanimal-cli/Program.cs
+++ b/kanimal-cli/Program.cs
@@ -146,6 +146,10 @@ namespace kanimal_cli
 
         private static void Main(string[] args)
         {
+            System.Globalization.CultureInfo customCulture = (System.Globalization.CultureInfo)System.Threading.Thread.CurrentThread.CurrentCulture.Clone();
+            customCulture.NumberFormat.NumberDecimalSeparator = ".";
+
+            System.Threading.Thread.CurrentThread.CurrentCulture = customCulture;
             Parser.Default
                 .ParseArguments<KanimToScmlOptions, ScmlToKanimOptions, GenericOptions, DumpOptions, BatchConvertOptions
                 >(args)

--- a/kanimal/Writer/KanimWriter.cs
+++ b/kanimal/Writer/KanimWriter.cs
@@ -47,13 +47,14 @@ namespace kanimal
             writer.Write("BILD".ToCharArray());
             writer.Write(10); // build version
             Logger.Debug("version=10");
-            writer.Write(BuildData.SymbolCount);
-            Logger.Debug($"symbols={BuildData.SymbolCount}");
+            writer.Write(BuildData.Symbols.Count);
+            Logger.Debug($"symbols={BuildData.Symbols.Count}");
             writer.Write(BuildData.FrameCount);
             Logger.Debug($"frames={BuildData.FrameCount}");
             writer.WritePString(BuildData.Name);
             Logger.Debug($"name={BuildData.Name}");
-            for (var i = 0; i < BuildData.SymbolCount; i++)
+
+            for (var i = 0; i < BuildData.Symbols.Count; i++)
             {
                 var symbol = BuildData.Symbols[i];
                 Logger.Debug(


### PR DESCRIPTION
Now works with locales, that have non-dot symbols as their decimal separators. Also fixes various bugs when new kanim works incorrectly inside game ([see this](https://forums.kleientertainment.com/forums/topic/116391-help-ui-placesymbol-0x0-is-missing/)).