### PR TITLE
Fix for animated alpha values not surviving conversion

### DIFF
--- a/kanimal/Reader/ScmlReader.cs
+++ b/kanimal/Reader/ScmlReader.cs
@@ -374,9 +374,13 @@ namespace kanimal
 
                         var element = new Element();
                         element.Flags = 0;
+                        // Spriter does support setting alpha per keyframe, so we grab that value for the alpha channel of the kanim element
+                        if (object_ref.HasAttribute("a"))
+                            element.A = float.Parse(object_ref.Attributes["a"].Value);
+                        else
+                            element.A = 1.0f;
                         // spriter does not support changing colors of components
                         // through animation so this can be safely set to 0
-                        element.A = 1.0f;
                         element.B = 1.0f;
                         element.G = 1.0f;
                         element.R = 1.0f;

--- a/kanimal/Writer/ScmlWriter.cs
+++ b/kanimal/Writer/ScmlWriter.cs
@@ -311,6 +311,7 @@ namespace kanimal
                     object_def.SetAttribute("angle", trans.Angle.ToStringInvariant());
                     object_def.SetAttribute("scale_x", trans.ScaleX.ToStringInvariant());
                     object_def.SetAttribute("scale_y", trans.ScaleY.ToStringInvariant());
+                    object_def.SetAttribute("a", element.A.ToStringInvariant());
 
                     keyframe.AppendChild(object_def);
                     timelineMap[idMap[name]].AppendChild(keyframe);


### PR DESCRIPTION
The kanim format has an embedded color for every element inside a keyframe.

Spriter only supports animating the alpha value for these so this update at least preserves the alpha animations when converting back and forth.