### PR TITLE
symbol ordering fix; ignoring <character_map> entry

### DIFF
--- a/kanimal/Reader/ScmlReader.cs
+++ b/kanimal/Reader/ScmlReader.cs
@@ -244,6 +244,11 @@ namespace kanimal
             var entity = scml.GetElementsByTagName("entity")[0];
             foreach (var animation in entity.ChildNodes.GetElements())
             {
+                if (animation.Name == "character_map")
+                {
+                    Logger.Debug("Skipping <character_map> child of <entity>");
+                    continue;
+                }
                 if (animation.Name != "animation")
                     throw new ProjectParseException(
                         $"SCML format exception: all children of <entity> should be <animation>, but was <{animation.Name}> instead.");
@@ -284,6 +289,11 @@ namespace kanimal
 
             foreach (var anim in animations)
             {
+                if (anim.Name == "character_map")
+                {
+                    Logger.Debug("Skipping <character_map> child of <entity>");
+                    continue;
+                }
                 animCount++;
                 if (anim.Name != "animation")
                     throw new ProjectParseException(
@@ -635,6 +645,11 @@ namespace kanimal
                 }
 
                 var anim = (XmlElement) child;
+                if (anim.Name == "character_map")
+                {
+                    Logger.Debug("Skipping <character_map> child of <entity>");
+                    continue;
+                }
                 if (anim.Name != "animation")
                     throw new ProjectParseException(
                         $"SCML format exception: all children of <entity> must be <animation>, was <{anim.Name}> instead.");

--- a/kanimal/Writer/KanimWriter.cs
+++ b/kanimal/Writer/KanimWriter.cs
@@ -65,6 +65,7 @@ namespace kanimal
                 writer.Write(symbol.Flags);
                 writer.Write(symbol.Frames.Count);
 
+                symbol.Frames.Sort( (a,b) => a.SourceFrameNum.CompareTo(b.SourceFrameNum));
                 for (var j = 0; j < symbol.Frames.Count; j++)
                 {
                     var frame = symbol.Frames[j];


### PR DESCRIPTION
when reading SCML dont throw error if <character_map> entry is present, just ignore it.

when writing kanim, write Symbols Frames in order of its SourceFrameNum,
not in the alphabetical order like 1 10 11 ...  19 2 20 21