### PR TITLE
keep color value of transparent pixels

### DIFF
--- a/kanimal-cli/kanimal-cli.csproj
+++ b/kanimal-cli/kanimal-cli.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.6.0" />
-    <PackageReference Include="NLog" Version="4.6.7" />
+    <PackageReference Include="NLog" Version="5.3.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/kanimal-tests/kanimal-tests.csproj
+++ b/kanimal-tests/kanimal-tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.0</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
         <RootNamespace>kanimal_tests</RootNamespace>
 
         <IsPackable>false</IsPackable>
@@ -12,7 +12,7 @@
         <PackageReference Include="nunit" Version="3.12.0" />
         <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-        <PackageReference Include="System.Drawing.Common" Version="4.7.0-preview1.19504.10" />
+        <PackageReference Include="System.Drawing.Common" Version="4.7.3" />
     </ItemGroup>
 
     <ItemGroup>

--- a/kanimal/Extensions/BitmapExtensions.cs
+++ b/kanimal/Extensions/BitmapExtensions.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Drawing;
+using System.Drawing.Imaging;
+
+namespace kanimal
+{
+    public static class BitmapExtensions
+    {
+        // direct copy pixels bytes to keep color value of transparent pixels
+        public static void CopyTo(this Bitmap src, Bitmap dst, int X, int Y)
+        {
+            var intersect = Rectangle.Intersect(
+                new Rectangle(0, 0, dst.Width, dst.Height),
+                new Rectangle(X, Y, src.Width, src.Height));
+            if (!intersect.IsEmpty)
+            {
+                var src_data = src.LockBits(
+                    new Rectangle(0, 0, src.Width, src.Height),
+                    ImageLockMode.ReadOnly, PixelFormat.Format32bppArgb);
+                int src_bytes_per_line = Math.Abs(src_data.Stride);
+                ReadOnlySpan<byte> src_bytes;
+                unsafe
+                {
+                    src_bytes = new ReadOnlySpan<byte>(src_data.Scan0.ToPointer(), src_bytes_per_line * src_data.Height);
+                }
+
+                var dst_data = dst.LockBits(
+                    new Rectangle(0, 0, dst.Width, dst.Height),
+                    ImageLockMode.ReadWrite, PixelFormat.Format32bppArgb);
+                int dst_bytes_per_line = Math.Abs(dst_data.Stride);
+                int bytes_per_px = dst_bytes_per_line / dst_data.Width;
+                Span<byte> dst_bytes;
+                unsafe
+                {
+                    dst_bytes = new Span<byte>(dst_data.Scan0.ToPointer(), dst_bytes_per_line * dst_data.Height);
+                }
+
+                int bytes_to_copy = intersect.Width * bytes_per_px;
+                for (int line = 0; line < intersect.Height; line++)
+                {
+                    src_bytes.Slice(((intersect.Y - Y + line) * src.Width + intersect.X - X) * bytes_per_px, bytes_to_copy)
+                        .CopyTo(dst_bytes.Slice(((intersect.Y + line) * dst.Width + intersect.X) * bytes_per_px, bytes_to_copy));
+                }
+                src.UnlockBits(src_data);
+                dst.UnlockBits(dst_data);
+            }
+        }
+    }
+}

--- a/kanimal/TexturePacker.cs
+++ b/kanimal/TexturePacker.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Drawing;
+using System.Drawing.Imaging;
 using System.Linq;
 using NLog;
 using MaxRectsBinPack;
@@ -84,12 +85,8 @@ namespace kanimal
                 else
                     sheetW *= 2;
 
-            using (var grD = Graphics.FromImage(SpriteSheet))
-            {
-                foreach (var sprite in SpriteAtlas)
-                    grD.DrawImage(sprite.Sprite,
-                        new Rectangle(sprite.X, sprite.Y, sprite.Width, sprite.Height));
-            }
+            foreach (var sprite in SpriteAtlas)
+                sprite.Sprite.CopyTo(SpriteSheet, sprite.X, sprite.Y);
 
             Logger.Info($"Packed {sheetW} x {sheetH}");
         }
@@ -117,7 +114,7 @@ namespace kanimal
                 SpriteAtlas.Add(new PackedSprite(rect.X, rect.Y, sprite));
             }
 
-            SpriteSheet = new Bitmap(sheet_w, sheet_h);
+            SpriteSheet = new Bitmap(sheet_w, sheet_h, PixelFormat.Format32bppArgb);
 
             return true;
         }

--- a/kanimal/kanimal.csproj
+++ b/kanimal/kanimal.csproj
@@ -1,9 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.0</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="NLog" Version="4.6.7" />
-        <PackageReference Include="System.Drawing.Common" Version="4.7.0-preview1.19504.10" />
+        <PackageReference Include="NLog" Version="5.3.4" />
+        <PackageReference Include="System.Drawing.Common" Version="4.7.3" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
When writing kanim, transparent pixels turn black which causes ugly halos around sprites, since the game mixing colors even transparent pixels.
Like this
![E70982BE-0456-4F1F-B3C2-E56FFF69770E](https://github.com/user-attachments/assets/d9e1e611-3748-432d-bcd1-a83ef84794e8)
Keep color value of transparent pixels by direct in-memory copy pixels bytes instead of Graphics.DrawImage
